### PR TITLE
tests: enable building root filesystem with dracut

### DIFF
--- a/.ci/openshift-ci/buildall_install.sh
+++ b/.ci/openshift-ci/buildall_install.sh
@@ -38,6 +38,7 @@ export experimental_kernel="false"
 
 # Configure to use the initrd rootfs.
 export TEST_INITRD="yes"
+export BUILD_WITH_DRACUT="yes"
 
 # Configure to use vsock.
 # TODO: install_runtime.sh will try to load the vsock module and the script


### PR DESCRIPTION
So far, install_kata_image.sh only supported building the root filesystem
image or initrd using the "distro" method.  This method however depends on
being able to run a container which causes trouble if the building process
runs in a container already as is the case for Openshift CI.

The dracut-based build method doesn't need to run a container and is thus
better suited for such an environment.

Signed-off-by: Pavel Mores <pmores@redhat.com>